### PR TITLE
Documented installation from unofficial Ubuntu PPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Before opening an issue, consider using one of the following locations to ensure
     - [openSUSE](#opensuse)
     - [Guix](#guix)
     - [Snap](#snap)
+    - [Ubuntu PPA](#ubuntu-ppa)
   - [Unofficial Windows packages](#unofficial-windows-packages)
     - [Chocolatey](#chocolatey)
     - [Scoop](#scoop)
@@ -203,6 +204,7 @@ $ ipfs get /ipns/dist.ipfs.tech/kubo/$VERSION/kubo_$VERSION_windows-amd64.zip   
 - [openSUSE](#opensuse)
 - [Guix](#guix)
 - [Snap](#snap)
+- [Ubuntu PPA](#ubuntu-ppa)
 
 #### Arch Linux
 
@@ -245,6 +247,31 @@ You can also install it through the Solus software center.
 #### Snap
 
 No longer supported, see rationale in [kubo#8688](https://github.com/ipfs/kubo/issues/8688).
+
+#### Ubuntu PPA
+
+[PPA homepage](https://launchpad.net/~twdragon/+archive/ubuntu/ipfs) on Launchpad.
+
+##### Latest Ubuntu (>= 20.04 LTS)
+```sh
+sudo add-apt-repository ppa:twdragon/ipfs
+sudo apt update
+sudo apt install ipfs-kubo
+```
+
+##### Any Ubuntu version
+
+```sh
+sudo su
+echo 'deb https://ppa.launchpadcontent.net/twdragon/ipfs/ubuntu <<DISTRO>> main' >> /etc/apt/sources.list.d/ipfs
+echo 'deb-src https://ppa.launchpadcontent.net/twdragon/ipfs/ubuntu <<DISTRO>> main' >> /etc/apt/sources.list.d/ipfs
+exit
+sudo apt update
+sudo apt install ipfs-kubo
+```
+where `<<DISTRO>>` is the codename of your Ubuntu distribution (for example, `jammy` for 22.04 LTS). During the first installation the package maintenance script may automatically ask you about which networking profile, CPU accounting model, and/or existing node configuration file you want to use.
+
+**NOTE**: this method also may work with any compatible Debian-based distro which has `libc6` inside, and APT as a package manager.
 
 ### Unofficial Windows packages
 


### PR DESCRIPTION
Documented unofficial Debian-compatible installation package located in Ubuntu PPA  maintained by @twdragon 

This PR is a preparation for automated build implementation on GitHub CI to obtain vanilla (possibly official) Debian packages. The PPA is intended to be a manifestation of the pilot project doing this.

Build scenarios development is centered in the [dedicated repository](https://github.com/twdragon/kubo-debian-pkg). When the CI pipeline is created, this repository may be included in the mainline Kubo tree as a submodule (or as a snippet, depending on the community).